### PR TITLE
speed up coreference resolution 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,16 @@ To install the project:
 pip install -e .
 ```
 
+## Development
+
+Code is formatted with `black`. 
+
+
 To add required packages to the environment.yml
 
 ```commandline
 conda env export > environment.yml --no-builds
 ```
-
-## Development
-
-Code is formatted with `black`. 
-
-To update enivornment.yml after changing dependencies, run `conda env export environment.yml`
 
 ## Data 
 

--- a/labeler/bin/main.py
+++ b/labeler/bin/main.py
@@ -53,11 +53,15 @@ if __name__ == "__main__":
     logging.info("Passive check complete")
 
     if process == "baseline":
+        logging.info("Running baseline predictions...")
+
         # lemmatiziation
         # semantic role labeling
         # baseline evaluation
         pass
     elif process == "model":
+        logging.info("Running model predictions...")
+
         # preprocess
         # train/test split
         # model - scores

--- a/labeler/consts.py
+++ b/labeler/consts.py
@@ -17,12 +17,28 @@ ANTHROPOMORPHIC_VERBS = [
     "admit",
 ]
 
+ANTHROPOMORPHIC_MULTIWORD_EXPRESSIONS = [
+    "is coming for",
+    "mess with",
+    "come up with",
+    "gets me",
+    "goes rogue",
+    "figure out",
+    "have an identity crisis",
+]
+
 MAYBE_VERBS = [
     "learn",
     "choose",
     "decide",
     "deduce",
     "determine",
+]
+
+MAGIC_WORDS = [
+    "divine",
+    "alchemy",
+    "magic",
 ]
 
 MODEL_LEXICON = [

--- a/labeler/utils/coref_resolution.py
+++ b/labeler/utils/coref_resolution.py
@@ -1,4 +1,7 @@
-from fastcoref import LingMessCoref, FCoref, spacy_component
+from fastcoref import FCoref, spacy_component
+# from fastcoref import LingMessCoref, spacy_component
+# LingMessCoref is a more accurate coreference resolution implementation, but it takes much longer to run
+# spacy_component is required with both libraries even though it is not directly called anywhere
 import spacy
 
 # library documentation: https://github.com/shon-otmazgin/fastcoref

--- a/labeler/utils/coref_resolution.py
+++ b/labeler/utils/coref_resolution.py
@@ -1,5 +1,7 @@
-from fastcoref import LingMessCoref, spacy_component
+from fastcoref import LingMessCoref, FCoref, spacy_component
 import spacy
+
+# library documentation: https://github.com/shon-otmazgin/fastcoref
 
 
 class CorefResolution:
@@ -7,7 +9,7 @@ class CorefResolution:
         self.text = text
 
     def resolve_coreferences(self):
-        model = LingMessCoref(device="mps")
+        model = FCoref(device="mps")
 
         nlp = spacy.load("en_core_web_sm")
         nlp.add_pipe("fastcoref")

--- a/labeler/utils/passivity_check.py
+++ b/labeler/utils/passivity_check.py
@@ -1,10 +1,11 @@
 from PassivePySrc import PassivePy
 
-# https://pypi.org/project/PassivePy/
+# library documentation: https://pypi.org/project/PassivePy/
 
 
 class PassiveChecker:
-    def __init__(self):
-        pass
+    def __init__(self, text):
+        self.text = text
 
-    passivepy = PassivePy.PassivePyAnalyzer(spacy_model="en_core_web_lg")
+    def check_for_passives(self):
+        passivepy = PassivePy.PassivePyAnalyzer(spacy_model="en_core_web_lg")


### PR DESCRIPTION
using FCoref instead of LingMessCoref for speed. LingMessCoref is supposed to be more accurate, but takes much longer. 

source: https://arxiv.org/abs/2209.04280

we can probably try some sort of parallelization later on, but this at least speeds up the process significantly.